### PR TITLE
Implement RPC for AMQP brokers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,12 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+
+[[package]]
+name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
@@ -288,7 +294,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
@@ -314,7 +320,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "cfg-if",
  "lazy_static",
 ]
@@ -390,6 +396,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,27 +436,6 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "futures-util",
-]
-
-[[package]]
-name = "futures-await-test"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0d3d05bce73a572ba581e4f4a7f20164c18150169c3a67f406aada3e48c7e8"
-dependencies = [
- "futures-await-test-macro",
- "futures-executor",
-]
-
-[[package]]
-name = "futures-await-test-macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f150175e6832600500334550e00e4dc563a0b32f58a9d1ad407f6473378c839"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -678,7 +669,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -818,7 +809,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -916,6 +907,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanoid"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6226bc4e142124cb44e309a37a04cd9bb10e740d8642855441d3b14808f635e"
+dependencies = [
+ "rand 0.6.5",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,7 +970,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "num-traits",
 ]
 
@@ -980,7 +980,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -1031,7 +1031,7 @@ version = "0.9.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "cc",
  "libc",
  "pkg-config",
@@ -1172,15 +1172,44 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.7",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1190,8 +1219,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1204,11 +1248,82 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1284,10 +1399,9 @@ name = "rustacles-brokers"
 version = "0.1.0"
 dependencies = [
  "env_logger",
- "futures 0.3.5",
- "futures-await-test",
  "lapin",
  "log",
+ "nanoid",
  "tokio",
 ]
 
@@ -1533,7 +1647,7 @@ checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if",
  "libc",
- "rand",
+ "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.8",
@@ -1737,7 +1851,7 @@ dependencies = [
  "input_buffer",
  "log",
  "native-tls",
- "rand",
+ "rand 0.7.3",
  "sha-1",
  "url",
  "utf-8",

--- a/brokers/Cargo.toml
+++ b/brokers/Cargo.toml
@@ -14,9 +14,8 @@ edition = "2018"
 lapin = "1.1"
 env_logger = "0.7"
 log = "0.4"
-futures-await-test = "0.3"
-futures = "0.3"
+nanoid = "0.3"
 
 [dependencies.tokio]
 version = "0.2"
-features = ["full"]
+features = ["stream", "macros", "rt-threaded", "sync"]

--- a/brokers/examples/amqp_consumer.rs
+++ b/brokers/examples/amqp_consumer.rs
@@ -1,14 +1,13 @@
 use std::env;
 
-use futures::StreamExt;
-
 use rustacles_brokers::amqp::AmqpBroker;
+use tokio::stream::StreamExt;
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    let amqp_uri = env::var("AMQP_URI").expect("No AMQP URI provided");
-    let broker = AmqpBroker::new(amqp_uri, "foo".to_string(), None)
+    let amqp_uri = env::var("AMQP_URI").unwrap_or("amqp://127.0.0.1:5672/%2f".into());
+    let broker = AmqpBroker::new(&amqp_uri, "foo".to_string(), None)
         .await
         .expect("Failed to initialize broker");
     let mut consumer = broker
@@ -16,10 +15,10 @@ async fn main() {
         .await
         .expect("Failed to consume event");
     println!("I'm now listening for messages!");
-    tokio::spawn(async move {
-        while let Some(payload) = consumer.next().await {
-            let string = std::str::from_utf8(&payload).expect("Failed to decode string");
-            println!("Message received: {}", string);
-        }
-    });
+    while let Some(payload) = consumer.next().await {
+        let string = std::str::from_utf8(&payload.data).expect("Failed to decode string");
+        println!("Message received: {}", string);
+    }
+
+    println!("Finished consumption");
 }

--- a/brokers/examples/amqp_consumer.rs
+++ b/brokers/examples/amqp_consumer.rs
@@ -15,8 +15,9 @@ async fn main() {
         .await
         .expect("Failed to consume event");
     println!("I'm now listening for messages!");
-    while let Some(payload) = consumer.next().await {
-        let string = std::str::from_utf8(&payload.data).expect("Failed to decode string");
+    while let Some(message) = consumer.next().await {
+        message.ack().await.expect("Unable to ack message");
+        let string = std::str::from_utf8(&message.data).expect("Failed to decode string");
         println!("Message received: {}", string);
     }
 

--- a/brokers/examples/amqp_producer.rs
+++ b/brokers/examples/amqp_producer.rs
@@ -4,8 +4,8 @@ use rustacles_brokers::amqp::{AmqpBroker, AmqpProperties};
 
 #[tokio::main]
 async fn main() {
-    let amqp_uri = env::var("AMQP_URI").expect("No AMQP URI provided");
-    let broker = AmqpBroker::new(amqp_uri, "foo".to_string(), None)
+    let amqp_uri = env::var("AMQP_URI").unwrap_or("amqp://127.0.0.1:5672/%2f".into());
+    let broker = AmqpBroker::new(&amqp_uri, "foo".to_string(), None)
         .await
         .expect("Failed to initialize broker");
     match broker

--- a/brokers/examples/amqp_rpc_consumer.rs
+++ b/brokers/examples/amqp_rpc_consumer.rs
@@ -15,11 +15,12 @@ async fn main() {
         .await
         .expect("Failed to consume event");
     println!("I'm now listening for messages!");
-    while let Some(payload) = consumer.next().await {
-        let string = std::str::from_utf8(&payload.data).expect("Failed to decode string");
+    while let Some(message) = consumer.next().await {
+        let string = std::str::from_utf8(&message.data).expect("Failed to decode string");
         println!("Message received: {}", string);
-        broker
-            .reply_to(&payload, string.as_bytes().to_vec())
+        message.ack().await.expect("Unable to ack message");
+        message
+            .reply(string.as_bytes().to_vec())
             .await
             .expect("Unable to send reply");
     }

--- a/brokers/examples/amqp_rpc_consumer.rs
+++ b/brokers/examples/amqp_rpc_consumer.rs
@@ -1,0 +1,23 @@
+use std::env;
+
+use rustacles_brokers::amqp::AmqpBroker;
+use tokio::stream::StreamExt;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let amqp_uri = env::var("AMQP_URI").unwrap_or("amqp://localhost:5672/%2f".into());
+    let broker = AmqpBroker::new(&amqp_uri, "foo".to_string(), None)
+        .await
+        .expect("Failed to initialize broker");
+    let mut consumer = broker
+        .consume("foobar")
+        .await
+        .expect("Failed to consume event");
+    println!("I'm now listening for messages!");
+    while let Some(payload) = consumer.next().await {
+        let string = std::str::from_utf8(&payload.data).expect("Failed to decode string");
+        println!("Message received: {}", string);
+        broker.reply_to(&payload, string.as_bytes().to_vec()).await.expect("Unable to send reply");
+    }
+}

--- a/brokers/examples/amqp_rpc_consumer.rs
+++ b/brokers/examples/amqp_rpc_consumer.rs
@@ -18,6 +18,9 @@ async fn main() {
     while let Some(payload) = consumer.next().await {
         let string = std::str::from_utf8(&payload.data).expect("Failed to decode string");
         println!("Message received: {}", string);
-        broker.reply_to(&payload, string.as_bytes().to_vec()).await.expect("Unable to send reply");
+        broker
+            .reply_to(&payload, string.as_bytes().to_vec())
+            .await
+            .expect("Unable to send reply");
     }
 }

--- a/brokers/examples/amqp_rpc_producer.rs
+++ b/brokers/examples/amqp_rpc_producer.rs
@@ -1,0 +1,25 @@
+use std::env;
+
+use rustacles_brokers::amqp::{AmqpBroker, AmqpProperties};
+
+#[tokio::main]
+async fn main() {
+    let amqp_uri = env::var("AMQP_URI").unwrap_or("amqp://127.0.0.1:5672/%2f".into());
+    let broker = AmqpBroker::new(&amqp_uri, "foo".to_string(), None)
+        .await
+        .expect("Failed to initialize broker")
+        .with_rpc()
+        .await
+        .expect("Unable to initialze RPC");
+    match broker
+        .call(
+            "foobar",
+            b"{'message': 'hello'}".to_vec(),
+            AmqpProperties::default(),
+        )
+        .await
+    {
+        Ok(d) => println!("Response received: {:?}", d),
+        Err(e) => panic!("Failed to publish message: {:?}", e),
+    };
+}

--- a/brokers/src/amqp.rs
+++ b/brokers/src/amqp.rs
@@ -5,10 +5,11 @@ use std::{
 
 use lapin::{
     BasicProperties, Channel, Connection, ConnectionProperties, ExchangeKind,
-    message::Delivery, options::*, types::FieldTable,
+    options::*, types::FieldTable,
 };
+pub use lapin::message::Delivery;
 use nanoid::nanoid;
-use tokio::{
+pub use tokio::{
     stream::StreamExt,
     sync::{
         mpsc,

--- a/brokers/src/errors.rs
+++ b/brokers/src/errors.rs
@@ -10,8 +10,21 @@ pub enum Error {
     Lapin(LapinError),
     Io(IoError),
     Recv(RecvError),
-    Reply,
+    Reply(String),
 }
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Lapin(e) => write!(f, "Lapin error: {}", e),
+            Error::Io(e) => write!(f, "IO error: {}", e),
+            Error::Recv(e) => write!(f, "Async receive error: {}", e),
+            Error::Reply(e) => write!(f, "Reply error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
 
 impl From<LapinError> for Error {
     fn from(err: LapinError) -> Self {

--- a/brokers/src/errors.rs
+++ b/brokers/src/errors.rs
@@ -1,6 +1,7 @@
 use lapin::Error as LapinError;
 
 use std::{io::Error as IoError, result::Result as StdResult};
+use tokio::sync::oneshot::error::RecvError;
 
 pub type Result<T> = StdResult<T, Error>;
 
@@ -8,10 +9,18 @@ pub type Result<T> = StdResult<T, Error>;
 pub enum Error {
     Lapin(LapinError),
     Io(IoError),
+    Recv(RecvError),
+    Reply,
 }
 
 impl From<LapinError> for Error {
     fn from(err: LapinError) -> Self {
         Error::Lapin(err)
+    }
+}
+
+impl From<RecvError> for Error {
+    fn from(err: RecvError) -> Self {
+        Error::Recv(err)
     }
 }


### PR DESCRIPTION
Implemented RPC for the AMQP broker and cleaned up some code & dependencies. This pretty closely mirrors the brokers.js implementation, so I'm open to a more idiomatic Rust implementation.